### PR TITLE
Unified Persistence System Implementation and Cleanup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod mcp;
 mod agents;
 mod rate_limit;
 mod system;
+mod persistence;
 
 use anyhow::Result;
 use clap::Parser;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -77,9 +77,11 @@ impl Orchestrator {
             AgentRegistry::new(config.agents.clone(), report.as_ref())
         ));
 
-        let rate_limiter = Arc::new(RwLock::new(
-            RateLimitTracker::new(config.rate_limiting.clone())
-        ));
+        let mut tracker = RateLimitTracker::new(config.rate_limiting.clone());
+        if let Err(e) = tracker.load_usage().await {
+            tracing::error!("❌ Failed to load rate limit usage: {}", e);
+        }
+        let rate_limiter = Arc::new(RwLock::new(tracker));
 
         let executor = Arc::new(
             AgentExecutor::new(
@@ -100,6 +102,7 @@ impl Orchestrator {
     pub async fn run_stdio(self) -> Result<()> {
         let executor = self.executor.clone();
         let agent_registry = self.agent_registry.clone();
+        let rate_limiter = self.rate_limiter.clone();
 
         // Build MCP server with typed tools
         let server = ServerBuilder::new()
@@ -139,6 +142,13 @@ impl Orchestrator {
 
         // Run the MCP server on stdio
         server.run_stdio().await?;
+
+        // Flush usage on shutdown
+        let rate_limiter = rate_limiter.read().await;
+        if let Err(e) = rate_limiter.flush_usage().await {
+            tracing::error!("❌ Failed to flush rate limit usage on shutdown: {}", e);
+        }
+
         Ok(())
     }
 }

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -62,7 +62,9 @@ impl Persistence {
                 .with_context(|| format!("Failed to create directory: {:?}", parent))?;
         }
 
-        let temp_path = path.with_extension("tmp");
+        let mut temp_name = path.as_os_str().to_os_string();
+        temp_name.push(".tmp");
+        let temp_path = PathBuf::from(temp_name);
         fs::write(&temp_path, content).await
             .with_context(|| format!("Failed to write to temporary file: {:?}", temp_path))?;
 

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -74,6 +74,8 @@ impl Persistence {
             fs::remove_file(path).await
                 .with_context(|| format!("Failed to remove existing file: {:?}", path))?;
         }
+
+        fs::rename(&temp_path, path).await
             .with_context(|| format!("Failed to rename {:?} to {:?}", temp_path, path))?;
 
         Ok(())

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -68,7 +68,12 @@ impl Persistence {
         fs::write(&temp_path, content).await
             .with_context(|| format!("Failed to write to temporary file: {:?}", temp_path))?;
 
-        fs::rename(&temp_path, path).await
+        // On Windows, rename fails if the destination already exists, so remove it first.
+        #[cfg(windows)]
+        if path.exists() {
+            fs::remove_file(path).await
+                .with_context(|| format!("Failed to remove existing file: {:?}", path))?;
+        }
             .with_context(|| format!("Failed to rename {:?} to {:?}", temp_path, path))?;
 
         Ok(())

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -1,0 +1,74 @@
+use anyhow::{Context, Result};
+use serde::{de::DeserializeOwned, Serialize};
+use std::path::{Path, PathBuf};
+use tokio::fs;
+
+pub enum StorageLocation {
+    Global,
+    Local,
+}
+
+pub struct Persistence {
+    base_path: PathBuf,
+}
+
+impl Persistence {
+    pub fn new(location: StorageLocation) -> Result<Self> {
+        let base_path = match location {
+            StorageLocation::Global => {
+                let home = std::env::var("HOME")
+                    .or_else(|_| std::env::var("USERPROFILE"))
+                    .context("Could not find home directory")?;
+                PathBuf::from(home).join(".config/bl1nk-agents-manager")
+            }
+            StorageLocation::Local => PathBuf::from("."),
+        };
+        Ok(Self { base_path })
+    }
+
+    pub async fn save_json<T: Serialize>(&self, relative_path: &str, data: &T) -> Result<()> {
+        let path = self.base_path.join(relative_path);
+        let content = serde_json::to_string_pretty(data)
+            .context("Failed to serialize to JSON")?;
+        self.atomic_write(&path, content).await
+    }
+
+    pub async fn load_json<T: DeserializeOwned>(&self, relative_path: &str) -> Result<T> {
+        let path = self.base_path.join(relative_path);
+        let content = fs::read_to_string(&path).await
+            .with_context(|| format!("Failed to read file: {:?}", path))?;
+        serde_json::from_str(&content)
+            .with_context(|| format!("Failed to deserialize JSON from {:?}", path))
+    }
+
+    pub async fn save_toml<T: Serialize>(&self, relative_path: &str, data: &T) -> Result<()> {
+        let path = self.base_path.join(relative_path);
+        let content = toml::to_string_pretty(data)
+            .context("Failed to serialize to TOML")?;
+        self.atomic_write(&path, content).await
+    }
+
+    pub async fn load_toml<T: DeserializeOwned>(&self, relative_path: &str) -> Result<T> {
+        let path = self.base_path.join(relative_path);
+        let content = fs::read_to_string(&path).await
+            .with_context(|| format!("Failed to read file: {:?}", path))?;
+        toml::from_str(&content)
+            .with_context(|| format!("Failed to deserialize TOML from {:?}", path))
+    }
+
+    async fn atomic_write(&self, path: &Path, content: String) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).await
+                .with_context(|| format!("Failed to create directory: {:?}", parent))?;
+        }
+
+        let temp_path = path.with_extension("tmp");
+        fs::write(&temp_path, content).await
+            .with_context(|| format!("Failed to write to temporary file: {:?}", temp_path))?;
+
+        fs::rename(&temp_path, path).await
+            .with_context(|| format!("Failed to rename {:?} to {:?}", temp_path, path))?;
+
+        Ok(())
+    }
+}

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -62,8 +62,12 @@ impl Persistence {
                 .with_context(|| format!("Failed to create directory: {:?}", parent))?;
         }
 
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
         let mut temp_name = path.as_os_str().to_os_string();
-        temp_name.push(".tmp");
+        temp_name.push(format!(".{}.{}.tmp", std::process::id(), nonce));
         let temp_path = PathBuf::from(temp_name);
         fs::write(&temp_path, content).await
             .with_context(|| format!("Failed to write to temporary file: {:?}", temp_path))?;

--- a/src/rate_limit.rs
+++ b/src/rate_limit.rs
@@ -79,8 +79,14 @@ impl RateLimitTracker {
                 }
                 Err(e) => {
                     tracing::warn!("Failed to load rate limit usage: {}. Starting fresh.", e);
-                    Err(e)
+                    self.usage.clear();
+                    Ok(())
                 }
+            }
+        } else {
+            Ok(())
+        }
+    }
             }
         } else {
             Ok(())

--- a/src/rate_limit.rs
+++ b/src/rate_limit.rs
@@ -87,11 +87,6 @@ impl RateLimitTracker {
             Ok(())
         }
     }
-            }
-        } else {
-            Ok(())
-        }
-    }
 
     pub async fn flush_usage(&self) -> anyhow::Result<()> {
         if let Some(ref p) = self.persistence {

--- a/src/rate_limit.rs
+++ b/src/rate_limit.rs
@@ -49,7 +49,13 @@ impl AgentUsage {
 impl RateLimitTracker {
     pub fn new(config: RateLimitingConfig) -> Self {
         let persistence = if config.track_usage {
-            Persistence::new(StorageLocation::Global).ok()
+            match Persistence::new(StorageLocation::Global) {
+                Ok(p) => Some(p),
+                Err(e) => {
+                    tracing::warn!("Failed to initialize persistence: {}. Usage tracking disabled.", e);
+                    None
+                }
+            }
         } else {
             None
         };

--- a/src/rate_limit.rs
+++ b/src/rate_limit.rs
@@ -69,14 +69,17 @@ impl RateLimitTracker {
 
     pub async fn load_usage(&mut self) -> anyhow::Result<()> {
         if let Some(ref p) = self.persistence {
-            match p.load_json::<HashMap<String, AgentUsage>>(&self.config.usage_db_path).await {
+            match p
+                .load_json::<HashMap<String, AgentUsage>>(&self.config.usage_db_path)
+                .await
+            {
                 Ok(usage) => {
                     self.usage = usage;
                     Ok(())
                 }
                 Err(e) => {
                     tracing::warn!("Failed to load rate limit usage: {}. Starting fresh.", e);
-                    Ok(())
+                    Err(e)
                 }
             }
         } else {

--- a/src/rate_limit.rs
+++ b/src/rate_limit.rs
@@ -1,13 +1,16 @@
 use crate::config::{RateLimitingConfig, RateLimit}; // เพิ่ม RateLimit เข้ามา
 use std::collections::HashMap;
 use chrono::{DateTime, Utc, Duration};
+use serde::{Deserialize, Serialize};
+use crate::persistence::{Persistence, StorageLocation};
 
 pub struct RateLimitTracker {
     config: RateLimitingConfig,
     usage: HashMap<String, AgentUsage>,
+    persistence: Option<Persistence>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct AgentUsage {
     requests_today: u32,
     requests_this_minute: u32,
@@ -45,10 +48,41 @@ impl AgentUsage {
 
 impl RateLimitTracker {
     pub fn new(config: RateLimitingConfig) -> Self {
+        let persistence = if config.track_usage {
+            Persistence::new(StorageLocation::Global).ok()
+        } else {
+            None
+        };
+
         Self {
             config,
             usage: HashMap::new(),
+            persistence,
         }
+    }
+
+    pub async fn load_usage(&mut self) -> anyhow::Result<()> {
+        if let Some(ref p) = self.persistence {
+            match p.load_json::<HashMap<String, AgentUsage>>(&self.config.usage_db_path).await {
+                Ok(usage) => {
+                    self.usage = usage;
+                    Ok(())
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to load rate limit usage: {}. Starting fresh.", e);
+                    Ok(())
+                }
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    pub async fn flush_usage(&self) -> anyhow::Result<()> {
+        if let Some(ref p) = self.persistence {
+            p.save_json(&self.config.usage_db_path, &self.usage).await?;
+        }
+        Ok(())
     }
 
     /// Check if agent can make a request and increment counter if yes.
@@ -59,42 +93,49 @@ impl RateLimitTracker {
             return true;
         }
 
-        let usage = self.usage
-            .entry(agent_id.to_string())
-            .or_insert_with(AgentUsage::new);
+        let (can_proceed, daily_limit, minute_limit, requests_today, requests_this_minute) = {
+            let usage = self.usage
+                .entry(agent_id.to_string())
+                .or_insert_with(AgentUsage::new);
 
-        usage.reset_if_needed();
+            usage.reset_if_needed();
 
-        // --- ส่วนที่แก้ไข: ใช้ค่า limit จากพารามิเตอร์ที่ส่งเข้ามา ---
-        let daily_limit = agent_limit.requests_per_day;
-        let minute_limit = agent_limit.requests_per_minute;
+            // --- ส่วนที่แก้ไข: ใช้ค่า limit จากพารามิเตอร์ที่ส่งเข้ามา ---
+            let daily_limit = agent_limit.requests_per_day;
+            let minute_limit = agent_limit.requests_per_minute;
 
-        if usage.requests_today >= daily_limit {
-            tracing::warn!(
-                "Agent {} hit daily rate limit ({} requests)", 
-                agent_id, daily_limit
-            );
+            if usage.requests_today >= daily_limit {
+                tracing::warn!(
+                    "Agent {} hit daily rate limit ({} requests)",
+                    agent_id, daily_limit
+                );
+                (false, daily_limit, minute_limit, usage.requests_today, usage.requests_this_minute)
+            } else if usage.requests_this_minute >= minute_limit {
+                tracing::warn!(
+                    "Agent {} hit per-minute rate limit ({} requests)",
+                    agent_id, minute_limit
+                );
+                (false, daily_limit, minute_limit, usage.requests_today, usage.requests_this_minute)
+            } else {
+                // Increment counters
+                usage.requests_today += 1;
+                usage.requests_this_minute += 1;
+                (true, daily_limit, minute_limit, usage.requests_today, usage.requests_this_minute)
+            }
+
+        };
+
+        if !can_proceed {
             return false;
         }
 
-        if usage.requests_this_minute >= minute_limit {
-            tracing::warn!(
-                "Agent {} hit per-minute rate limit ({} requests)", 
-                agent_id, minute_limit
-            );
-            return false;
-        }
-
-        // Increment counters
-        usage.requests_today += 1;
-        usage.requests_this_minute += 1;
 
         tracing::debug!(
             "Agent {} usage: {}/{} per day, {}/{} per minute",
             agent_id,
-            usage.requests_today,
+            requests_today,
             daily_limit,
-            usage.requests_this_minute,
+            requests_this_minute,
             minute_limit
         );
 

--- a/src/system/discovery.rs
+++ b/src/system/discovery.rs
@@ -2,8 +2,8 @@ use serde::{Deserialize, Serialize};
 use chrono::{DateTime, Utc};
 use tokio::process::Command;
 use std::path::PathBuf;
-use tokio::fs;
 use anyhow::{Result, Context};
+use crate::persistence::{Persistence, StorageLocation};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolInfo {
@@ -31,16 +31,8 @@ impl DiscoveryReport {
     }
 
     pub async fn load() -> Result<Self> {
-        let config_dir = DiscoveryEngine::get_config_dir()?;
-        let report_path = config_dir.join("discovery.json");
-
-        let content = fs::read_to_string(&report_path).await
-            .with_context(|| format!("Failed to read discovery report from: {:?}", report_path))?;
-
-        let report: DiscoveryReport = serde_json::from_str(&content)
-            .context("Failed to deserialize discovery report")?;
-
-        Ok(report)
+        let persistence = Persistence::new(StorageLocation::Global)?;
+        persistence.load_json("discovery.json").await
     }
 }
 
@@ -73,27 +65,11 @@ impl DiscoveryEngine {
     }
 
     pub async fn save(report: &DiscoveryReport) -> Result<()> {
-        let config_dir = Self::get_config_dir()?;
-        fs::create_dir_all(&config_dir).await
-            .with_context(|| format!("Failed to create config directory: {:?}", config_dir))?;
+        let persistence = Persistence::new(StorageLocation::Global)?;
+        persistence.save_json("discovery.json", report).await?;
 
-        let report_path = config_dir.join("discovery.json");
-        let content = serde_json::to_string_pretty(report)
-            .context("Failed to serialize discovery report")?;
-
-        fs::write(&report_path, content).await
-            .with_context(|| format!("Failed to write discovery report to: {:?}", report_path))?;
-
-        tracing::info!("✅ Discovery report saved to: {:?}", report_path);
+        tracing::info!("✅ Discovery report saved to global storage");
         Ok(())
-    }
-
-    fn get_config_dir() -> Result<PathBuf> {
-        let home = std::env::var("HOME")
-            .or_else(|_| std::env::var("USERPROFILE"))
-            .context("Could not find home directory")?;
-
-        Ok(PathBuf::from(home).join(".config/bl1nk-agents-manager"))
     }
 
     async fn check_tool(name: &str) -> ToolInfo {


### PR DESCRIPTION
## **User description**
Implement a unified persistence layer in `src/persistence/mod.rs` to centralize JSON/TOML storage across the system. Refactor `DiscoveryEngine` and `RateLimitTracker` to use this new API, ensuring atomic writes and consistent storage paths. Address code review feedback by optimizing persistence performance and fixing potential build issues.

Fixes #8

*PR created automatically by Jules for task [716099449823813388](https://jules.google.com/task/716099449823813388) started by @billlzzz18*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Unified Persistence System Implementation

This PR introduces a centralized persistence layer (`src/persistence/mod.rs`) to standardize JSON/TOML storage across the system, addressing issue #8. The implementation provides both Global (user config directory at `~/.config/bl1nk-agents-manager/`) and Local storage locations with atomic write semantics.

### Key Changes

**New Persistence Module** (`src/persistence/mod.rs`):
- Added `StorageLocation` enum (`Global`, `Local`) and `Persistence` struct.
- Async methods for JSON/TOML: `save_json`/`load_json`, `save_toml`/`load_toml`.
- Atomic write strategy: write to a uniquely named temporary file in the destination directory then rename (Windows-safe removal when needed).
- Ensures parent-directory creation and returns `anyhow::Result` with contextual errors.

**Refactored RateLimitTracker** (`src/rate_limit.rs`):
- Added optional `persistence: Option<Persistence>` field; persistence initialized only when configured (graceful degradation/logging if init fails).
- Added `pub async fn load_usage(&mut self)` and `pub async fn flush_usage(&self)` to restore and persist `AgentUsage`.
- `AgentUsage` now derives `Serialize`/`Deserialize`.
- Startup attempts to load persisted usage; shutdown attempts to flush usage. On load failure, falls back to fresh counts and logs a warning.
- `check_and_increment()` refactored for clearer scoped computation and consistent logging.

**Refactored DiscoveryEngine** (`src/system/discovery.rs`):
- Replaced manual home-dir path handling and direct `tokio::fs` usage with `Persistence::load_json("discovery.json")` and `save_json("discovery.json", report).await?`.
- Removed `get_config_dir()` and related direct filesystem code; logging simplified.

**Orchestrator Integration** (`src/mcp/mod.rs`):
- `Orchestrator::new()` attempts async `load_usage()` before wrapping the tracker in `Arc<RwLock<_>>`; load failures are logged.
- `run_stdio()` captures the rate limiter and calls `flush_usage()` on shutdown, logging errors without blocking shutdown.

**Module Registration** (`src/main.rs`):
- Added `mod persistence;` declaration.

### Design Highlights
- Centralized persistence API supporting JSON/TOML and Global/Local locations.
- Atomic write semantics and parent-directory creation to reduce corruption risk.
- Designed to work with existing thread-safety patterns (Arc/RwLock).
- Persistence is optional and degrades gracefully when unavailable.

### Acceptance Criteria Mapping (Issue #8)
- `src/persistence/` added: ✓
- Global and Local storage locations implemented: ✓
- At least two hooks refactored to use it (discovery + rate limit): ✓
- Atomic write semantics implemented (temp + rename, Windows handling): ✓
- Thread-safety readiness (Arc/RwLock patterns used): ✓
- Removal of scattered per-module storage usage: appears satisfied by migrations in this PR.

### Notes on UI/UX / Responsiveness / Accessibility / Frontend Performance
- The checklist items (UI/UX design system conformance, responsive testing, ARIA attributes, React.memo/useMemo) are not applicable to this PR because changes are backend Rust code focused on persistence and non-UI modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Keep discovery data and rate-limit usage across restarts

### What Changed
- Discovery results are now saved and loaded from the same shared storage location, so the app can reuse the last scan instead of starting over
- Rate-limit usage is loaded when the app starts and written back when it shuts down, so usage tracking continues after a restart
- If saved usage data cannot be read, the app starts with fresh counters instead of failing
- Discovery saves now use a safer write flow that helps avoid corrupted saved files

### Impact
`✅ Discovery results survive restarts`
`✅ Rate limits keep working after reboot`
`✅ Fewer lost usage counters`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
