### PR TITLE
Improve persistence robustness and shutdown handling

### DIFF
--- a/config_test.toml
+++ b/config_test.toml
@@ -20,7 +20,7 @@ rules = []
 [rate_limiting]
 strategy = "round-robin"
 track_usage = true
-usage_db_path = "/tmp/usage_test.db"
+usage_db_path = "usage_test.db"
 
 [logging]
 level = "info"

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -143,15 +143,28 @@ impl Orchestrator {
         // Run the MCP server on stdio with signal handling for clean shutdown
         let server_handle = server.run_stdio();
 
+        let mut server_error = None;
         tokio::select! {
             result = server_handle => {
                 if let Err(e) = result {
                     tracing::error!("❌ MCP server error: {}", e);
+                    server_error = Some(e);
                 }
             }
             _ = tokio::signal::ctrl_c() => {
                 tracing::info!("Received Ctrl-C, shutting down...");
             }
+        }
+
+        // Flush usage on shutdown
+        let rate_limiter = rate_limiter.read().await;
+        if let Err(e) = rate_limiter.flush_usage().await {
+            tracing::error!("❌ Failed to flush rate limit usage on shutdown: {}", e);
+        }
+
+        match server_error {
+            Some(e) => Err(e.into()),
+            None => Ok(()),
         }
 
         // Flush usage on shutdown

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -140,8 +140,19 @@ impl Orchestrator {
             )
             .build()?;
 
-        // Run the MCP server on stdio
-        server.run_stdio().await?;
+        // Run the MCP server on stdio with signal handling for clean shutdown
+        let server_handle = server.run_stdio();
+
+        tokio::select! {
+            result = server_handle => {
+                if let Err(e) = result {
+                    tracing::error!("❌ MCP server error: {}", e);
+                }
+            }
+            _ = tokio::signal::ctrl_c() => {
+                tracing::info!("Received Ctrl-C, shutting down...");
+            }
+        }
 
         // Flush usage on shutdown
         let rate_limiter = rate_limiter.read().await;

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -26,15 +26,23 @@ impl Persistence {
         Ok(Self { base_path })
     }
 
+    fn validate_relative_path(&self, relative_path: &str) -> Result<PathBuf> {
+        let path = Path::new(relative_path);
+        if path.is_absolute() {
+            return Err(anyhow::anyhow!("relative_path must not be an absolute path: {}", relative_path));
+        }
+        Ok(self.base_path.join(relative_path))
+    }
+
     pub async fn save_json<T: Serialize>(&self, relative_path: &str, data: &T) -> Result<()> {
-        let path = self.base_path.join(relative_path);
+        let path = self.validate_relative_path(relative_path)?;
         let content = serde_json::to_string_pretty(data)
             .context("Failed to serialize to JSON")?;
         self.atomic_write(&path, content).await
     }
 
     pub async fn load_json<T: DeserializeOwned>(&self, relative_path: &str) -> Result<T> {
-        let path = self.base_path.join(relative_path);
+        let path = self.validate_relative_path(relative_path)?;
         let content = fs::read_to_string(&path).await
             .with_context(|| format!("Failed to read file: {:?}", path))?;
         serde_json::from_str(&content)
@@ -42,14 +50,14 @@ impl Persistence {
     }
 
     pub async fn save_toml<T: Serialize>(&self, relative_path: &str, data: &T) -> Result<()> {
-        let path = self.base_path.join(relative_path);
+        let path = self.validate_relative_path(relative_path)?;
         let content = toml::to_string_pretty(data)
             .context("Failed to serialize to TOML")?;
         self.atomic_write(&path, content).await
     }
 
     pub async fn load_toml<T: DeserializeOwned>(&self, relative_path: &str) -> Result<T> {
-        let path = self.base_path.join(relative_path);
+        let path = self.validate_relative_path(relative_path)?;
         let content = fs::read_to_string(&path).await
             .with_context(|| format!("Failed to read file: {:?}", path))?;
         toml::from_str(&content)
@@ -69,19 +77,27 @@ impl Persistence {
         let mut temp_name = path.as_os_str().to_os_string();
         temp_name.push(format!(".{}.{}.tmp", std::process::id(), nonce));
         let temp_path = PathBuf::from(temp_name);
+
         fs::write(&temp_path, content).await
             .with_context(|| format!("Failed to write to temporary file: {:?}", temp_path))?;
 
-        // On Windows, rename fails if the destination already exists, so remove it first.
-        #[cfg(windows)]
-        if path.exists() {
-            fs::remove_file(path).await
-                .with_context(|| format!("Failed to remove existing file: {:?}", path))?;
+        let result = async {
+            // On Windows, rename fails if the destination already exists, so remove it first.
+            #[cfg(windows)]
+            if fs::try_exists(path).await.unwrap_or(false) {
+                fs::remove_file(path).await
+                    .with_context(|| format!("Failed to remove existing file: {:?}", path))?;
+            }
+
+            fs::rename(&temp_path, path).await
+                .with_context(|| format!("Failed to rename {:?} to {:?}", temp_path, path))?;
+            Ok(())
+        }.await;
+
+        if result.is_err() {
+            let _ = fs::remove_file(&temp_path).await;
         }
 
-        fs::rename(&temp_path, path).await
-            .with_context(|| format!("Failed to rename {:?} to {:?}", temp_path, path))?;
-
-        Ok(())
+        result
     }
 }

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -89,9 +89,14 @@ impl Persistence {
         let result = async {
             // On Windows, rename fails if the destination already exists, so remove it first.
             #[cfg(windows)]
-            if fs::try_exists(path).await.unwrap_or(false) {
-                fs::remove_file(path).await
-                    .with_context(|| format!("Failed to remove existing file: {:?}", path))?;
+            {
+                match fs::remove_file(path).await {
+                    Ok(()) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => {
+                        return Err(e).with_context(|| format!("Failed to remove existing file: {:?}", path));
+                    }
+                }
             }
 
             fs::rename(&temp_path, path).await

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -28,10 +28,15 @@ impl Persistence {
 
     fn validate_relative_path(&self, relative_path: &str) -> Result<PathBuf> {
         let path = Path::new(relative_path);
-        if path.is_absolute() {
-            return Err(anyhow::anyhow!("relative_path must not be an absolute path: {}", relative_path));
+        if path.is_absolute()
+            || path.components().any(|c| matches!(c, std::path::Component::ParentDir | std::path::Component::Prefix(_)))
+        {
+            return Err(anyhow::anyhow!(
+                "relative_path must be a safe relative path within base directory: {}",
+                relative_path
+            ));
         }
-        Ok(self.base_path.join(relative_path))
+        Ok(self.base_path.join(path))
     }
 
     pub async fn save_json<T: Serialize>(&self, relative_path: &str, data: &T) -> Result<()> {

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -31,12 +31,25 @@ impl Persistence {
         if path.is_absolute()
             || path.components().any(|c| matches!(c, std::path::Component::ParentDir | std::path::Component::Prefix(_)))
         {
-            return Err(anyhow::anyhow!(
-                "relative_path must be a safe relative path within base directory: {}",
-                relative_path
-            ));
+    fn validate_relative_path(&self, relative_path: &str) -> Result<PathBuf> {
+        let path = Path::new(relative_path);
+        if path.is_absolute() {
+            return Err(anyhow::anyhow!("relative_path must not be an absolute path: {}", relative_path));
         }
-        Ok(self.base_path.join(path))
+        // Block path traversal attempts
+        let joined = self.base_path.join(relative_path);
+        // Use lexical normalization to detect traversal without filesystem access
+        let mut normalized = PathBuf::new();
+        for component in joined.components() {
+            match component {
+                std::path::Component::ParentDir => { normalized.pop(); }
+                c => normalized.push(c.as_os_str()),
+            }
+        }
+        if !normalized.starts_with(&self.base_path) {
+            return Err(anyhow::anyhow!("relative_path escapes base directory: {}", relative_path));
+        }
+        Ok(joined)
     }
 
     pub async fn save_json<T: Serialize>(&self, relative_path: &str, data: &T) -> Result<()> {

--- a/src/rate_limit.rs
+++ b/src/rate_limit.rs
@@ -52,7 +52,7 @@ impl RateLimitTracker {
             match Persistence::new(StorageLocation::Global) {
                 Ok(p) => Some(p),
                 Err(e) => {
-                    tracing::warn!("Failed to initialize persistence: {}. Usage tracking disabled.", e);
+                    tracing::error!("Failed to initialize persistence: {}. Usage tracking disabled.", e);
                     None
                 }
             }
@@ -69,6 +69,11 @@ impl RateLimitTracker {
 
     pub async fn load_usage(&mut self) -> anyhow::Result<()> {
         if let Some(ref p) = self.persistence {
+            // Validate that usage_db_path is not absolute to avoid bypassing Global storage
+            if std::path::Path::new(&self.config.usage_db_path).is_absolute() {
+                anyhow::bail!("usage_db_path must not be an absolute path: {}", self.config.usage_db_path);
+            }
+
             match p
                 .load_json::<HashMap<String, AgentUsage>>(&self.config.usage_db_path)
                 .await
@@ -90,6 +95,11 @@ impl RateLimitTracker {
 
     pub async fn flush_usage(&self) -> anyhow::Result<()> {
         if let Some(ref p) = self.persistence {
+            // Validate that usage_db_path is not absolute to avoid bypassing Global storage
+            if std::path::Path::new(&self.config.usage_db_path).is_absolute() {
+                anyhow::bail!("usage_db_path must not be an absolute path: {}", self.config.usage_db_path);
+            }
+
             p.save_json(&self.config.usage_db_path, &self.usage).await?;
         }
         Ok(())

--- a/src/rate_limit.rs
+++ b/src/rate_limit.rs
@@ -71,7 +71,12 @@ impl RateLimitTracker {
         if let Some(ref p) = self.persistence {
             // Validate that usage_db_path is not absolute to avoid bypassing Global storage
             if std::path::Path::new(&self.config.usage_db_path).is_absolute() {
-                anyhow::bail!("usage_db_path must not be an absolute path: {}", self.config.usage_db_path);
+                tracing::warn!(
+                    "Absolute usage_db_path is not supported for global persistence: {}. Starting fresh.",
+                    self.config.usage_db_path
+                );
+                self.usage.clear();
+                return Ok(());
             }
 
             match p


### PR DESCRIPTION
## **User description**
This PR improves the robustness of the persistence and rate-limiting systems. Key changes include:
1. Strict validation to prevent absolute paths from being used in persistence operations, ensuring they stay within the intended base directory.
2. Improved atomic write logic with unique temporary filenames and automatic cleanup on failure.
3. Full transition to asynchronous file existence checks on Windows.
4. Guaranteed flushing of rate limit usage data by intercepting termination signals (Ctrl-C) and handling server errors within the orchestrator's run loop.
5. More prominent error logging for persistence failures in the rate limiter.

Fixes #17

---
*PR created automatically by Jules for task [2753037297362686715](https://jules.google.com/task/2753037297362686715) started by @billlzzz18*


___

## **CodeAnt-AI Description**
**Make shutdown flush usage data and block unsafe storage paths**

### What Changed
- The app now catches Ctrl-C during shutdown, then finishes by saving rate-limit usage before exiting.
- If the server stops with an error, it now logs that failure clearly instead of exiting silently.
- Saving and loading stored data now reject absolute file paths, so data stays inside the intended storage folder.
- Failed file writes now clean up leftover temporary files, reducing the chance of clutter or broken partial saves.
- Rate-limit storage setup failures are now reported as errors, and the test config now uses a safe relative path.

### Impact
`✅ Fewer lost usage stats on shutdown`
`✅ Safer storage path handling`
`✅ Fewer leftover temp files after save failures`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Improvements to Persistence, Rate-Limiting, and Shutdown Handling

### Persistence Security and Robustness
- **Path Validation**: Added `validate_relative_path()` helper that rejects absolute paths and detects path traversal attempts (e.g., `../../../etc/passwd`) through lexical normalization, ensuring all file operations remain within the intended base directory.
- **Atomic Write with Unique Temp Files**: Replaced fixed `.tmp` suffix with unique temporary filenames using PID + nanosecond timestamp (e.g., `filename.12345.123456789.tmp`) to prevent collisions. Temporary files are cleaned up if the rename operation fails.
- **Path Validation in All Operations**: All public methods (`save_json`, `load_json`, `save_toml`, `load_toml`) now validate the relative path before accessing the filesystem.

### Rate-Limiting Improvements
- **Error Visibility**: Changed `Persistence::new()` failure logging from `tracing::warn!` to `tracing::error!` to make initialization issues more visible.
- **Absolute Path Prevention**: Added validation in both `load_usage()` and `flush_usage()` to reject absolute `usage_db_path` values, preventing bypasses of the `StorageLocation::Global` security model. `load_usage()` logs a warning and starts fresh, while `flush_usage()` returns an error.

### Shutdown Handling
- **Signal Interception**: Modified server startup to use handle-based execution with `tokio::select!` to concurrently monitor for either server completion or Ctrl-C signal, ensuring graceful shutdown is always triggered.
- **Usage Data Persistence on Shutdown**: Added explicit `flush_usage()` call during shutdown sequence to guarantee rate-limit usage data is persisted before the process terminates, regardless of whether shutdown was initiated by Ctrl-C or server error.

### Notable Issue
The implementation contains duplicate shutdown flush logic (lines 159-163 and 170-174 in `src/mcp/mod.rs`), causing `flush_usage()` to be called twice in normal shutdown scenarios. This should be consolidated to a single flush operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->