### PR TITLE
Fix for Empty except

### DIFF
--- a/.kilo/skills/skill-creator/eval-viewer/generate_review.py
+++ b/.kilo/skills/skill-creator/eval-viewer/generate_review.py
@@ -133,7 +133,9 @@ def build_run(root: Path, run_dir: Path) -> dict | None:
             try:
                 grading = json.loads(candidate.read_text())
             except (json.JSONDecodeError, OSError):
-                pass
+                # Ignore malformed/unreadable optional grading files and
+                # continue checking other candidate locations.
+                continue
             if grading:
                 break
 


### PR DESCRIPTION
To fix this without changing functionality, keep the exception handling logic (continue scanning candidate grading files) but replace the empty `pass` with an explanatory comment and `continue`. This preserves behavior exactly while satisfying the rule by documenting intent.

Edit `.kilo/skills/skill-creator/eval-viewer/generate_review.py` in `build_run`, in the grading-load loop around lines 133–136:
- Change the `except (json.JSONDecodeError, OSError): pass` block to:
  - comment explaining that invalid/unreadable optional grading files are ignored so other candidates can be tried.
  - `continue` to make control flow explicit.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._